### PR TITLE
Update nippy, expose -from-string and -to-string to pod

### DIFF
--- a/src/brisk/main.clj
+++ b/src/brisk/main.clj
@@ -98,7 +98,11 @@
      :pod/vars [{:var/name "freeze-to-file"
                  :var/fn #(count (nippy/freeze-to-file %1 %2))}
                 {:var/name "thaw-from-file"
-                 :var/fn nippy/thaw-from-file}]}]})
+                 :var/fn nippy/thaw-from-file}
+                {:var/name "freeze-to-string"
+                 :var/fn nippy/freeze-to-string}
+                {:var/name "thaw-from-string"
+                 :var/fn nippy/thaw-from-string}]}]})
 
 (defn -main [& args]
   (let [parsed (parse-opts args cli-options)


### PR DESCRIPTION
Being able to work with strings in babashka is quite useful, eg. for writing simple filters meant to work with stdin and stdout. 

This PR extends the pod config to expose `nippy/freeze-to-string` and `nippy/thaw-from-string`.

It also bumps ptaoussanis/nippy to the current version. The changelog indicates some breaking changes around advanced use, but that don't seem likely to affect the types of ad-hoc uses that I think tend to arise from CLI or babashka pod uses.

See #1.
